### PR TITLE
Smaller cache values.

### DIFF
--- a/gpg/gpg-agent.conf
+++ b/gpg/gpg-agent.conf
@@ -1,5 +1,5 @@
-default-cache-ttl 7200
-max-cache-ttl 86400
-max-cache-ttl-ssh 7200
+default-cache-ttl 600
+max-cache-ttl 7200
+max-cache-ttl-ssh 3600
 enable-ssh-support
 


### PR DESCRIPTION
Use smaller value so the key is usable without a password for a shorter period of time.