### PR TITLE
Adiciona nível de bateria pra fone de ouvido

### DIFF
--- a/i3/polybar/config
+++ b/i3/polybar/config
@@ -212,7 +212,7 @@ format-padding = 1
 
 [module/jbl-tunebt-500]
 type = custom/script
-exec = ~/.i3/polybar/scripts/bt-device-status.sh "TUNE" "" "ﳌ"
+exec = ~/.i3/polybar/scripts/bt-device-status.sh "TUNE|EDIFIER" "" "ﳌ" --show-battery
 interval = 5
 format-padding = 1
 format-background = ${colors.background-alt}

--- a/i3/polybar/scripts/bt-device-status.sh
+++ b/i3/polybar/scripts/bt-device-status.sh
@@ -6,17 +6,17 @@ ICON_PAIRED=${2:-}
 ICON_NOT_PAIRED=${3:-ﳌ}
 
 BAT_PERCENTAGE=""
+SHOW_BATT=""
 
 bluetooth_print() {
         if [ "$(systemctl is-active "bluetooth.service")" = "active" ]; then
-            device_paired=$(bluetoothctl paired-devices | grep "${DEVICE_NAME}" | grep Device | cut -d ' ' -f 2)
+            device_paired=$(bluetoothctl devices Connected | grep -E "${DEVICE_NAME}" | grep Device | cut -d ' ' -f 2)
             if [ -n "${device_paired}" ]; then
               device_info=$(bluetoothctl info "${device_paired}")
               upower_object="$(echo ${device_paired} | tr ':' '_')"
 
-              has_upower_support=$(upower -e | grep ${upower_object})
-              if [ -n "${has_upower_support}" ]; then
-                BAT_PERCENTAGE=" $(upower -i ${has_upower_support} | grep -i perc | cut -d ':' -f 2 | tr -d ' ')%"
+              if [ ! -z ${SHOW_BATT} ]; then
+                BAT_PERCENTAGE=" $(pactl list | grep battery | grep -oE "[0-9]+")%%"
               fi
 
               if echo "$device_info" | grep -q "Connected: yes"; then
@@ -32,4 +32,23 @@ bluetooth_print() {
         fi
 }
 
-bluetooth_print
+
+main() {
+  for opt in "$@"
+  do
+    case "${opt}" in
+      --show-battery)
+        SHOW_BATT="yes"
+        ;;
+  #   icon-on) ICON_PAIRED=${opt}
+  #      ;;
+  #    icon-off) ICON_NOT_PAIRED=${opt}
+  #      ;;
+  #    device-name) DEVICE_NAME=${opt}
+  #      ;;
+    esac
+  done
+  bluetooth_print
+}
+
+main "$@"


### PR DESCRIPTION
Alguns fones possuem suporte a fornecer o nível de bateria via
bluetooth. O comando `pactl` muitas vezes consegue ver esse número.
